### PR TITLE
i18n improvements

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,16 +1,33 @@
 <?php
-/*
-Plugin Name: Revue
-Description: The Revue plugin allows you to quickly add a signup form for your Revue list.
-Version: 1.1.0
-Author: Revue
-Author URI: https://www.getrevue.co
-*/
+/**
+ * Plugin Name:   Revue
+ * Description:   The Revue plugin allows you to quickly add a signup form for your Revue list.
+ * Author:        Revue
+ * Author URI:    https://www.getrevue.co
+ * Version:       1.2.0-alpha
+ * Text Domain:   revue
+ * Domain Path:   /languages/
+ * License:       GPLv2 (or later)
+ */
 
-define( 'REVUE_TRANS_DOMAIN', 'revue' );
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+include_once 'widget.php';
+
 $_revue_printed_forms = 0;
 
-include_once 'widget.php';
+
+add_action( 'plugins_loaded', 'revue_load_textdomain' );
+/**
+ * Load textdomain
+ *
+ * @since 1.2
+ */
+function revue_load_textdomain() {
+	$lang_dir = dirname( plugin_basename( __FILE__ ) ) . '/languages/';
+	load_plugin_textdomain( 'revue', false, $lang_dir );
+}
 
 
 function revue_ajaxurl() {
@@ -28,10 +45,10 @@ function revue_admin_settings() {
 	<div class="wrap wrap-revue">
 		<img src="<?php echo plugins_url( 'images/logo.png', __FILE__ ); ?>" style="margin-top: 20px; width: 100px;"/>
 
-		<p style="font-size: 18px; line-height: 28px;margin-bottom: 40px;">In order to connect to Revue, we need you to
+		<p style="font-size: 18px; line-height: 28px;margin-bottom: 40px;">
+			<?php echo sprintf( __( 'In order to connect to Revue, we need you to
 			enter your API key. You can find<br/>
-			this key on the bottom of the <a target="_blank" style="color: #E15718;"
-			                                 href="https://www.getrevue.co/app/integrations">Integrations page.</a>
+			this key on the bottom of the <a target="_blank" style="color: #E15718;"  href="%s">Integrations page.</a>', 'revue' ), 'https://www.getrevue.co/app/integrations' ); ?>
 		</p>
 
 		<form method="post" action="options.php">
@@ -43,8 +60,9 @@ function revue_admin_settings() {
 			?>
 		</form>
 
-		<p style="color: #999;font-size: 12px;margin-top: 20px;">Need help? Just <a style="color: #999;" href="mailto:support@getrevue.co">shoot
-				us an email</a>.</p>
+		<p style="color: #999;font-size: 12px;margin-top: 20px;">
+			<?php echo sprintf( __( 'Need help? Just <a style="color: #999;" href="%s">shoot us an email</a>.', 'revue' ), 'mailto:support@getrevue.co' ) ?>
+		</p>
 	</div>
 	<?php
 }
@@ -78,14 +96,14 @@ function revue_page_init() {
 
 	add_settings_section(
 		'revue_api_settings', // ID
-		__( 'API Settings', REVUE_TRANS_DOMAIN ), // Title
+		__( 'API Settings', 'revue' ), // Title
 		null,
 		'revue-settings' // Page
 	);
 
 	add_settings_field(
 		'api_key', // ID
-		__( 'Fill out your API key:', REVUE_TRANS_DOMAIN ),
+		__( 'Fill out your API key:', 'revue'),
 		'revue_api_key_callback',
 		'revue-settings', // Page
 		'revue_api_settings' // Section
@@ -107,7 +125,7 @@ function revue_subscribe_callback() {
 
 	echo json_encode( array(
 		'thank_you' => sprintf(
-			'Thanks for subscribing to my email digest. You can find older issues <a href="%s">here</a> via <a href="%s">Revue</a>.',
+			__('Thanks for subscribing to my email digest. You can find older issues <a href="%s">here</a> via <a href="%s">Revue</a>.','revue'),
 			revue_get_profile_url(),
 			'https://www.getrevue.co/?utm_campaign=Wordpress+plugin&utm_content=Confirmation&utm_medium=web'
 		)
@@ -124,16 +142,16 @@ function revue_subscribe_form() {
 	$_revue_printed_forms ++;
 
 	if ( ! _revue_key_provided() ) {
-		return 'Please provide an API key in the Revue settings.';
+		return __( 'Please provide an API key in the Revue settings.', 'revue' );
 	}
 
 	$res = '';
 
 	$res .= '<div class="revue-subscribe">';
-	$res .= _revue_print_field( 'E-mail', 'revue_email', 'email' );
-	$res .= _revue_print_field( 'Firstname', 'revue_first_name', 'text' );
-	$res .= _revue_print_field( 'Lastname', 'revue_last_name', 'text' );
-	$res .= '<button type="submit">' . __( 'Subscribe', REVUE_TRANS_DOMAIN ) . '</button>';
+	$res .= _revue_print_field( __( 'E-mail', 'revue' ), 'revue_email', 'email' );
+	$res .= _revue_print_field( __( 'Firstname', 'revue' ), 'revue_first_name', 'text' );
+	$res .= _revue_print_field( __( 'Lastname', 'revue' ), 'revue_last_name', 'text' );
+	$res .= '<button type="submit">' . __( 'Subscribe', 'revue' ) . '</button>';
 	$res .= '</div>';
 
 	return $res;
@@ -149,7 +167,7 @@ function _revue_print_field( $label, $name, $type ) {
 	$res = '';
 
 	$res .= '<p>';
-	$res .= '<label for="' . $id . '">' . __( $label, REVUE_TRANS_DOMAIN ) . '</label><br>';
+	$res .= '<label for="' . $id . '">' .$label. '</label><br>';
 	$res .= '<input type="' . $type . '" name="' . $name . '" id="' . $id . '" />';
 	$res .= '</p>';
 
@@ -232,7 +250,7 @@ add_action( 'admin_head', 'revue_admin_styles' );
 
 function revue_admin_placeholder() {
 	echo '<script type="text/javascript">';
-	echo 'jQuery(function($) { $(".wrap-revue #api_key").attr("placeholder", "Your API key"); });';
+	echo 'jQuery(function($) { $(".wrap-revue #api_key").attr("placeholder", ' . __( "Your API key", 'revue') . '); });';
 	echo '</script>';
 }
 

--- a/languages/revue.pot
+++ b/languages/revue.pot
@@ -1,0 +1,109 @@
+# Copyright (C) 2018 Revue
+# This file is distributed under the GPLv2 (or later).
+msgid ""
+msgstr ""
+"Project-Id-Version: Revue 1.2.0-alpha\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/index\n"
+"POT-Creation-Date: 2018-01-08 18:33:26+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2018-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: grunt-wp-i18n 0.5.4\n"
+"X-Poedit-KeywordsList: "
+"__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_"
+"attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-Country: United States\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: ../\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-Bookmarks: \n"
+"X-Textdomain-Support: yes\n"
+
+#: index.php:49
+msgid ""
+"In order to connect to Revue, we need you to\n"
+"\t\t\tenter your API key. You can find<br/>\n"
+"\t\t\tthis key on the bottom of the <a target=\"_blank\" style=\"color: "
+"#E15718;\"  href=\"%s\">Integrations page.</a>"
+msgstr ""
+
+#: index.php:64
+msgid "Need help? Just <a style=\"color: #999;\" href=\"%s\">shoot us an email</a>."
+msgstr ""
+
+#: index.php:99
+msgid "API Settings"
+msgstr ""
+
+#: index.php:106
+msgid "Fill out your API key:"
+msgstr ""
+
+#: index.php:128
+msgid ""
+"Thanks for subscribing to my email digest. You can find older issues <a "
+"href=\"%s\">here</a> via <a href=\"%s\">Revue</a>."
+msgstr ""
+
+#: index.php:145
+msgid "Please provide an API key in the Revue settings."
+msgstr ""
+
+#: index.php:151
+msgid "E-mail"
+msgstr ""
+
+#: index.php:152
+msgid "Firstname"
+msgstr ""
+
+#: index.php:153
+msgid "Lastname"
+msgstr ""
+
+#: index.php:154
+msgid "Subscribe"
+msgstr ""
+
+#: index.php:253
+msgid "Your API key"
+msgstr ""
+
+#: widget.php:12
+msgid "Revue subscription widget"
+msgstr ""
+
+#: widget.php:14
+msgid "Subscribe users to your Revue list"
+msgstr ""
+
+#: widget.php:29
+msgid "New title"
+msgstr ""
+
+#: widget.php:32
+msgid "Please provide an API key under Settings > Revue"
+msgstr ""
+
+#: widget.php:37
+msgid "Title:"
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Revue"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"The Revue plugin allows you to quickly add a signup form for your Revue "
+"list."
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "https://www.getrevue.co"
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: revue
 Donate link:
 Tags: subscription, email
 Requires at least: 4.0
-Tested up to: 4.5
+Tested up to: 4.9
 Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/widget.php
+++ b/widget.php
@@ -1,13 +1,17 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 class Revue_Widget extends WP_Widget {
 
 	function __construct() {
 		parent::__construct(
 			'revue_widget',
-			__( 'Revue subscription widget', REVUE_TRANS_DOMAIN ),
+			__( 'Revue subscription widget', 'revue' ),
 			array(
-				'description' => __( 'Subscribe users to your Revue list', REVUE_TRANS_DOMAIN ),
+				'description' => __( 'Subscribe users to your Revue list', 'revue' ),
 			)
 		);
 	}
@@ -22,15 +26,15 @@ class Revue_Widget extends WP_Widget {
 	}
 
 	public function form( $instance ) {
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : __( 'New title', 'text_domain' );
+		$title = ! empty( $instance['title'] ) ? $instance['title'] : __( 'New title', 'revue' );
 
 		if ( ! _revue_key_provided() ) {
-			echo '<p>Please provide an API key under Settings > Revue</p>';
+			echo '<p>' . __( 'Please provide an API key under Settings > Revue', 'revue' ) . '</p>';
 		}
 
 		?>
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:' ); ?></label>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'revue' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>"
 			       name="<?php echo $this->get_field_name( 'title' ); ?>" type="text"
 			       value="<?php echo esc_attr( $title ); ?>">


### PR DESCRIPTION
WordPress uses `Text Domain:` plugin header to parse and build automatic language package for the GlotPress platform.

You might want to check: https://markjaquith.wordpress.com/2011/10/06/translating-wordpress-plugins-and-themes-dont-get-clever/ and https://make.wordpress.org/meta/handbook/documentation/translations/

Thanks :)