### PR TITLE
Plugin update

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Revue
 Description: The Revue plugin allows you to quickly add a signup form for your Revue list.
-Version: 1.1.0
+Version: 1.2.0
 Author: Revue
 Author URI: https://www.getrevue.co
 */

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: revue
 Donate link:
 Tags: subscription, email
 Requires at least: 4.0
-Tested up to: 4.5
-Stable tag: 1.1.0
+Tested up to: 4.9.8
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Hey!

Small PR to update the plugin to be tested up to `4.9.8`. Tested everything locally, installed the plugin, entered the api key, placed the widget in a sidebar, subscribed to the Revue user by using the widget.

- [x] Bumped plugin version up to `1.2.0`
- [x] Bumped version tested up to: `4.9.8`